### PR TITLE
75 backend set up api keys

### DIFF
--- a/app/Http/Controllers/JwtTokenController.php
+++ b/app/Http/Controllers/JwtTokenController.php
@@ -5,21 +5,38 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Firebase\JWT\JWT;
+use App\Models\User;
 
 class JwtTokenController extends Controller
 {
     public function __invoke(Request $request)
     {
-        $user = Auth::user();
-
+        // The API key middleware has already authenticated the group
+        $group = $request->attributes->get('group');
+        
+        // Get the user from the request
+        $userId = $request->input('user_id');
+        
+        if (!$userId) {
+            return response()->json(['error' => 'User ID is required'], 400);
+        }
+        
+        $user = User::find($userId);
+        
         if (!$user) {
-            return response()->json(['error' => 'Unauthorized'], 401);
+            return response()->json(['error' => 'User not found'], 404);
+        }
+        
+        // Ensure the user belongs to the authenticated group
+        if ($user->group_id != $group->id) {
+            return response()->json(['error' => 'User does not belong to the authenticated group'], 403);
         }
 
         $payload = [
             'iss' => 'yrgobanken.vip',
             'sub' => $user->id,
             'email' => $user->email,
+            'group_id' => $user->group_id,
             'iat' => time(),
             'exp' => time() + (60 * 60), // 1 hour
         ];

--- a/app/Http/Controllers/StampController.php
+++ b/app/Http/Controllers/StampController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\StoreStampRequest;
 use App\Http\Requests\UpdateStampRequest;
 use App\Models\Stamp;
 use App\Http\Resources\StampResource;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class StampController extends Controller
 {
@@ -15,6 +16,12 @@ class StampController extends Controller
     public function index()
     {
         $stamps = Stamp::all();
+
+        if ($stamps->isEmpty()) {
+            return response()->json([
+                'message' => 'No stamps available.',
+            ], 404);
+        }
 
         return StampResource::collection($stamps);
     }
@@ -40,9 +47,16 @@ class StampController extends Controller
      */
     public function show($id)
     {
-        $stamp = Stamp::findOrFail($id);
+        try {
+            $stamp = Stamp::findOrFail($id);
 
-        return new StampResource($stamp);
+            return new StampResource($stamp);
+
+        } catch (ModelNotFoundException $exception) {
+            return response()->json([
+                'message' => 'Stamp not found',
+            ], 404);
+        }
     }
 
     /**

--- a/app/Http/Middleware/ApiAuthentication.php
+++ b/app/Http/Middleware/ApiAuthentication.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Group;
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiAuthentication
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // First, check for API key
+        $apiKey = $request->header('X-API-Key');
+        
+        if (!$apiKey) {
+            return response()->json(['error' => 'API key is missing'], 401);
+        }
+        
+        // Find the group by API key
+        $group = Group::where('api_key', $apiKey)->first();
+        
+        if (!$group) {
+            return response()->json(['error' => 'Invalid API key'], 401);
+        }
+        
+        // Add group to the request attributes for controllers
+        $request->attributes->add(['group' => $group]);
+        
+        // Check for JWT token for user authentication
+        $token = $request->bearerToken();
+        
+        if ($token) {
+            try {
+                // Decode the token and authenticate the user
+                $payload = \Firebase\JWT\JWT::decode(
+                    $token, 
+                    new \Firebase\JWT\Key(env('JWT_SECRET'), 'HS256')
+                );
+                
+                // Find the user
+                $user = User::find($payload->sub);
+                
+                // Verify the user belongs to the authenticated group
+                if ($user && $user->group_id == $group->id) {
+                    Auth::login($user);
+                    $request->attributes->add(['user' => $user]);
+                }
+            } catch (\Exception $e) {
+                // Token is invalid, but we'll still proceed since API key is valid
+                // Just won't set an authenticated user
+            }
+        }
+        
+        return $next($request);
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -10,6 +10,8 @@ class Group extends Model
 {
     use HasFactory, HasApiTokens;
 
+    protected $fillable = ['api_key'];
+
     /** A group has many members (users) */
     public function users()
     {

--- a/app/Models/Stamp.php
+++ b/app/Models/Stamp.php
@@ -20,9 +20,9 @@ class Stamp extends Model
     /** A stamp belongs to a user */
     public function users()
     {
-        return $this->belongsToMany(User::class, 'user_stamps')
-                    ->withPivot('amusement_id', 'collected_at')
-                    ->withTimestamps();
+        return $this->belongsToMany(User::class, 'user_stamp')
+            ->withPivot('id', 'created_at', 'updated_at')
+            ->withTimestamps();
     }
     
     public function userStamps()

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,10 +18,8 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
-        ]);
-
-        $middleware->alias([
             'json.accept' => \App\Http\Middleware\ForceAcceptJson::class,
+            'api.auth' => \App\Http\Middleware\ApiAuthentication::class,
         ]);
 
         //

--- a/config/api-keys.php
+++ b/config/api-keys.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'groups' => [
+        1 => env('GROUP1_API_KEY', 'default_key_1'),
+        2 => env('GROUP2_API_KEY', 'default_key_2'),
+        3 => env('GROUP3_API_KEY', 'default_key_3'),
+        4 => env('GROUP4_API_KEY', 'default_key_4'),
+        5 => env('GROUP5_API_KEY', 'default_key_5'),
+        6 => env('GROUP6_API_KEY', 'default_key_6'),
+        7 => env('GROUP7_API_KEY', 'default_key_7'),
+        8 => env('GROUP8_API_KEY', 'default_key_8'),
+    ],
+];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,9 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\Group;
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -14,9 +12,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
         $this->call(GroupSeeder::class);
+        $this->call(GroupApiKeySeeder::class);
 
         User::factory()->count(10)->create();
 
@@ -32,13 +29,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         $this->call(AmusementSeeder::class);
-
         $this->call(TransactionSeeder::class);
-
         $this->call(StampSeeder::class);
-
-        $this->call([
-            GroupApiKeySeeder::class,
-        ]);
     }
 }

--- a/database/seeders/GroupApiKeySeeder.php
+++ b/database/seeders/GroupApiKeySeeder.php
@@ -13,19 +13,23 @@ class GroupApiKeySeeder extends Seeder
      */
     public function run(): void
     {
-        // Gå igenom alla grupper i databasen
-        $groups = Group::all();
-
-        foreach ($groups as $group) {
-            // Radera gamla tokens (frivilligt men rekommenderat)
-            $group->tokens()->delete();
-
-            // Skapa en ny Sanctum-token
-            $token = $group->createToken('Group API Token');
-            $plainTextToken = $token->plainTextToken;
-
-            // Visa i terminal
-            echo "Group ID {$group->id} API Key: {$plainTextToken}\n";
+        $apiKeys = config('api-keys.groups');
+        
+        foreach ($apiKeys as $groupId => $apiKey) {
+            // Find or create the group
+            $group = Group::firstOrCreate(
+                ['id' => $groupId],
+                [
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            );
+            
+            // Update the group with the API key
+            $group->update(['api_key' => $apiKey]);
+            
+            // Output the key for reference
+            $this->command->info("Group ID {$group->id} API Key: {$apiKey}");
         }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,15 +8,12 @@ use App\Http\Controllers\GroupController;
 use App\Http\Controllers\AmusementController;
 use App\Http\Controllers\TransactionController;
 use App\Http\Controllers\StampController;
-use App\Http\Middleware\ForceAcceptJson;
 use App\Http\Controllers\VoteController;
 use App\Http\Controllers\UserController;
 
 Route::middleware(['auth:sanctum'])->get('/user', function (Request $request) {
     return $request->user();
 });
-
-Route::middleware('auth:sanctum')->get('/jwt-token', JwtTokenController::class);
 
 Route::get('/test', [TestController::class, 'ping']);
 
@@ -27,8 +24,15 @@ Route::apiResource('/groups', GroupController::class);
 
 Route::apiResource('amusements', AmusementController::class)->middleware('json.accept');
 
-Route::apiResource('/transactions', TransactionController::class)->middleware('json.accept');
-
-Route::apiResource('/stamps', StampController::class);
-
 Route::apiResource('/votes', VoteController::class)->middleware('json.accept');
+
+Route::middleware(['api.auth', 'json.accept'])->group(function () {
+    Route::apiResource('/transactions', TransactionController::class);
+    Route::apiResource('/stamps', StampController::class);
+    
+    // JWT token route - only accessible with valid API key //VIKTOR: does this need to be protected by api.auth?
+    Route::get('/jwt-token', JwtTokenController::class);
+});
+
+// VIKTOR: should this be protected by api.auth?
+// Route::middleware('auth:sanctum')->get('/jwt-token', JwtTokenController::class);


### PR DESCRIPTION
API keys are now handled by our .env but leverages Sanctum. 
Current thoughts:
We need to restrict what users can access - right now, they can access all groups through the API keys. Fixing this seemed outside this issue's scope, so we should create a new task for that. 