### PR TITLE
Add stamp_id required

### DIFF
--- a/app/Http/Requests/StoreTransactionRequest.php
+++ b/app/Http/Requests/StoreTransactionRequest.php
@@ -108,8 +108,8 @@ public function withValidator($validator)
         }
 
         // Always pay out a stamp
-        if ($this->filled('payout_amount') && !$this->filled('stamp_id')) {
-            $validator->errors()->add('stamp_id', 'A stamp must be provided when payout amount is given.');
+        if (!$this->filled('stake_amount') && !$this->filled('stamp_id')) {
+            $validator->errors()->add('stamp_id', 'A stamp must be provided.');
             return;
         }
 


### PR DESCRIPTION
Test in postman showed that balance is spent between users, however stamp_id was not required for each payout. Closing until further bugs appear.